### PR TITLE
Translate spec to atd + new fields to support whole filenames like 'Dockerfile'

### DIFF
--- a/lang.atd
+++ b/lang.atd
@@ -1,0 +1,72 @@
+(*
+   Type definition for the list of languages supported by Semgrep.
+
+   semgrep: https://github.com/returntocorp/semgrep
+   atd: https://atd.readthedocs.io/en/latest/
+*)
+
+type languages = language list
+
+type language = {
+  (* Unique language identifier of the form [a-z][a-z0-9]+ *)
+  id: string;
+
+  (* Human-readable language name *)
+  name: string;
+
+  (* Values that identify this language uniquely in addition
+     to the 'id' field. This list may be empty since the language 'id'
+     is an implicit member. Members must be of the form [a-z][a-z0-9]+
+     like the main 'id'.
+
+     For example, these language keys are those used by the --lang option of
+     the 'semgrep' command. *)
+  ~keys: string list;
+
+  (* Extensions that are exclusive to this language.
+     Semgrep can use them to uniquely assign a language to a file.
+     For example, if '.c' is listed here, a file ending in '.c'
+     will be assumed to be in this language and no other. No two languages
+     may have overlapping 'reverse_exts'.
+
+     An extension must start with a period and continue with a nonempty
+     sequence of graphical ASCII characters i.e. it must match the pattern
+     \.[[:graph:]]+ *)
+  ~reverse_exts: string list;
+
+  (* Additional file extensions that Semgrep will scan for this language.
+     It extends the value of 'reverse_exts'. Extensions listed here may not be
+     exclusive to this language. *)
+  ~exts: string list;
+
+  (* File extensions that Semgrep will skip even if one of them is a suffix. *)
+  ~excluded_exts: string list;
+
+  (* This language's example file's extension.
+     It defaults to the first extension found in 'reverse_exts' or 'exts'.
+     If no valid extension is known from 'reverse_exts' and 'exts, a
+     nonempty extension must be provided here. *)
+  ?example_ext: string option;
+
+  maturity: maturity;
+
+  (* Programs that execute scripts written in this language; may be empty. *)
+  ~shebangs: string list;
+
+  (* An arbitrary list of string tags; these are useful to replace a
+     hard-coded switch on languages in a program tags.
+     TODO: this field is unused. Remove it? *)
+  (*tags: string list;*)
+}
+
+(*
+   Maturity of the support for the language in Semgrep.
+   'Alpha' displays as "Experimental" in documentation.
+   'Develop' is hidden altogether.
+*)
+type maturity = [
+  | GA <json name="ga">
+  | Beta <json name="beta">
+  | Alpha <json name="alpha">
+  | Develop <json name="develop">
+]

--- a/lang.atd
+++ b/lang.atd
@@ -11,13 +11,12 @@ type language = {
   (* Unique language identifier of the form [a-z][a-z0-9]+ *)
   id: string;
 
-  (* Human-readable language name *)
+  (* Human-readable language name e.g. 'C++' or 'Fortran 90' *)
   name: string;
 
   (* Values that identify this language uniquely in addition
      to the 'id' field. This list may be empty since the language 'id'
-     is an implicit member. Members must be of the form [a-z][a-z0-9]+
-     like the main 'id'.
+     is an implicit member. Members don't have to be of a particular form.
 
      For example, these language keys are those used by the --lang option of
      the 'semgrep' command. *)
@@ -31,20 +30,28 @@ type language = {
 
      An extension must start with a period and continue with a nonempty
      sequence of graphical ASCII characters i.e. it must match the pattern
-     \.[[:graph:]]+ *)
+     \.[[:graph:]]+
+
+     The same logic applies to field names containing 'filename' instead
+     of 'ext'. A file name is an exact name for a file rather than just
+     a suffix. Examples include 'Makefile' and 'package.json'.
+  *)
   ~reverse_exts: string list;
+  ~reverse_filenames: string list;
 
   (* Additional file extensions that Semgrep will scan for this language.
      It extends the value of 'reverse_exts'. Extensions listed here may not be
      exclusive to this language. *)
   ~exts: string list;
+  ~filenames: string list;
 
   (* File extensions that Semgrep will skip even if one of them is a suffix. *)
   ~excluded_exts: string list;
+  ~excluded_filenames: string list;
 
   (* This language's example file's extension.
      It defaults to the first extension found in 'reverse_exts' or 'exts'.
-     If no valid extension is known from 'reverse_exts' and 'exts, a
+     If no valid extension is known from 'reverse_exts' or 'exts, a
      nonempty extension must be provided here. *)
   ?example_ext: string option;
 
@@ -54,9 +61,8 @@ type language = {
   ~shebangs: string list;
 
   (* An arbitrary list of string tags; these are useful to replace a
-     hard-coded switch on languages in a program tags.
-     TODO: this field is unused. Remove it? *)
-  (*tags: string list;*)
+     hard-coded switch on languages in a program tags. *)
+  ~tags: string list;
 }
 
 (*

--- a/lang.json
+++ b/lang.json
@@ -3,7 +3,8 @@
     "id": "bash",
     "name": "Bash",
     "keys": ["bash", "sh"],
-    "exts": [".bash", ".sh"],
+    "reverse_exts": [".bash"],
+    "exts": [".sh"],
     "example_ext": ".sh",
     "maturity": "alpha",
     "shebangs": ["bash", "sh"]
@@ -12,34 +13,34 @@
     "id": "c",
     "name": "C",
     "keys": ["c"],
-    "exts": [".c"],
-    "maturity": "alpha",
-    "shebangs": []
+    "reverse_exts": [".c"],
+    "example_ext": ".sh",
+    "maturity": "alpha"
   },
   {
     "id": "cpp",
     "name": "C++",
     "keys": ["cpp", "c++"],
-    "exts": [".cc", ".cpp"],
+    "reverse_exts": [".cc", ".cpp"],
     "example_ext": ".cpp",
-    "maturity": "alpha",
-    "shebangs": []
+    "maturity": "alpha"
   },
   {
     "id": "csharp",
     "name": "C#",
     "keys": ["csharp", "c#"],
-    "exts": [".cs"],
-    "maturity": "ga",
-    "shebangs": []
+    "reverse_exts": [".cs"],
+    "example_ext": ".cs",
+    "maturity": "ga"
   },
   {
     "id": "dockerfile",
     "name": "Dockerfile",
     "keys": ["dockerfile", "docker"],
-    "exts": ["Dockerfile", ".dockerfile"],
-    "maturity": "alpha",
-    "shebangs": []
+    "reverse_exts": [".dockerfile"],
+    "example_ext": ".dockerfile",
+    "reverse_filenames": ["Dockerfile"],
+    "maturity": "alpha"
   },
   {
     "id": "generic",
@@ -47,22 +48,22 @@
     "keys": ["generic"],
     "exts": [""],
     "example_ext": ".generic",
-    "maturity": "alpha",
-    "shebangs": []
+    "maturity": "alpha"
   },
   {
     "id": "go",
     "name": "Go",
     "keys": ["go", "golang"],
-    "exts": [".go"],
-    "maturity": "ga",
-    "shebangs": []
+    "reverse_exts": [".go"],
+    "example_ext": ".go",
+    "maturity": "ga"
   },
   {
     "id": "hack",
     "name": "Hack",
     "keys": ["hack"],
-    "exts": [".hack", ".hck", ".hh"],
+    "reverse_exts": [".hack", ".hck"],
+    "exts": [".hh"],
     "example_ext": ".hack",
     "maturity": "develop",
     "shebangs": ["hhvm"]
@@ -71,8 +72,11 @@
     "id": "html",
     "name": "HTML",
     "keys": ["html"],
-    "exts": [".htm", ".html"],
+    "reverse_exts": [".htm", ".html"],
+    "exts": [],
     "example_ext": ".html",
+    "reverse_filenames": [],
+    "filenames": [],
     "maturity": "alpha",
     "shebangs": []
   },
@@ -80,15 +84,14 @@
     "id": "java",
     "name": "Java",
     "keys": ["java"],
-    "exts": [".java"],
-    "maturity": "ga",
-    "shebangs": []
+    "reverse_exts": [".java"],
+    "maturity": "ga"
   },
   {
     "id": "js",
     "name": "JavaScript",
     "keys": ["js", "javascript"],
-    "exts": [".js", ".jsx"],
+    "reverse_exts": [".js", ".jsx"],
     "excluded_exts": [".min.js"],
     "example_ext": ".jsx",
     "maturity": "ga",
@@ -99,24 +102,22 @@
     "id": "json",
     "name": "JSON",
     "keys": ["json"],
-    "exts": [".json"],
-    "maturity": "ga",
-    "shebangs": []
+    "reverse_exts": [".json"],
+    "maturity": "ga"
   },
   {
     "id": "kotlin",
     "name": "Kotlin",
     "keys": ["kt", "kotlin"],
-    "exts": [".kt", ".kts", ".ktm"],
+    "reverse_exts": [".kt", ".kts", ".ktm"],
     "example_ext": ".kt",
-    "maturity": "beta",
-    "shebangs": []
+    "maturity": "beta"
   },
   {
     "id": "lua",
     "name": "Lua",
     "keys": ["lua"],
-    "exts": [".lua"],
+    "reverse_exts": [".lua"],
     "maturity": "alpha",
     "shebangs": ["lua"]
   },
@@ -124,7 +125,7 @@
     "id": "ocaml",
     "name": "OCaml",
     "keys": ["ocaml"],
-    "exts": [".ml", ".mli"],
+    "reverse_exts": [".ml", ".mli"],
     "example_ext": ".ml",
     "maturity": "alpha",
     "shebangs": ["ocaml", "ocamlscript"]
@@ -133,7 +134,7 @@
     "id": "php",
     "name": "PHP",
     "keys": ["php"],
-    "exts": [".php"],
+    "reverse_exts": [".php"],
     "maturity": "alpha",
     "shebangs": ["php"]
   },
@@ -141,8 +142,7 @@
     "id": "python2",
     "name": "Python 2",
     "keys": ["python2"],
-    "exts": [".py", ".pyi"],
-    "reverse_exts": [],
+    "reverse_exts": [".py", ".pyi"],
     "example_ext": ".py",
     "maturity": "develop",
     "shebangs": ["python", "python2"],
@@ -152,8 +152,7 @@
     "id": "python3",
     "name": "Python 3",
     "keys": ["python3"],
-    "exts": [".py", ".pyi"],
-    "reverse_exts": [],
+    "reverse_exts": [".py", ".pyi"],
     "example_ext": ".py",
     "maturity": "develop",
     "shebangs": ["python", "python3"],
@@ -163,7 +162,7 @@
     "id": "python",
     "name": "Python",
     "keys": ["py", "python"],
-    "exts": [".py", ".pyi"],
+    "reverse_exts": [".py", ".pyi"],
     "example_ext": ".py",
     "maturity": "ga",
     "shebangs": ["python", "python2", "python3"],
@@ -173,7 +172,7 @@
     "id": "r",
     "name": "R",
     "keys": ["r"],
-    "exts": [".r", ".R"],
+    "reverse_exts": [".r", ".R"],
     "example_ext": ".R",
     "maturity": "develop"
   },
@@ -182,14 +181,13 @@
     "name": "regex",
     "keys": ["regex", "none"],
     "exts": [""],
-    "reverse_exts": [],
     "maturity": "develop"
   },
   {
     "id": "ruby",
     "name": "Ruby",
     "keys": ["ruby"],
-    "exts": [".rb"],
+    "reverse_exts": [".rb"],
     "maturity": "ga",
     "shebangs": ["ruby"]
   },
@@ -197,7 +195,7 @@
     "id": "rust",
     "name": "Rust",
     "keys": ["rust"],
-    "exts": [".rs"],
+    "reverse_exts": [".rs"],
     "maturity": "alpha",
     "shebangs": ["run-cargo-script"]
   },
@@ -205,7 +203,7 @@
     "id": "scala",
     "name": "Scala",
     "keys": ["scala"],
-    "exts": [".scala"],
+    "reverse_exts": [".scala"],
     "maturity": "beta",
     "shebangs": ["scala"]
   },
@@ -214,22 +212,20 @@
     "name": "Solidity",
     "keys": ["solidity", "sol"],
     "exts": [".sol"],
-    "maturity": "alpha",
-    "shebangs": []
+    "maturity": "alpha"
   },
   {
     "id": "hcl",
     "name": "Terraform",
     "keys": ["tf", "hcl", "terraform"],
-    "exts": [".tf"],
-    "maturity": "beta",
-    "shebangs": []
+    "reverse_exts": [".tf"],
+    "maturity": "beta"
   },
   {
     "id": "ts",
     "name": "TypeScript",
     "keys": ["ts", "typescript"],
-    "exts": [".ts", ".tsx"],
+    "reverse_exts": [".ts", ".tsx"],
     "excluded_exts": [".d.ts"],
     "example_ext": ".tsx",
     "maturity": "ga",
@@ -240,17 +236,15 @@
     "id": "vue",
     "name": "Vue",
     "keys": ["vue"],
-    "exts": [".vue"],
-    "maturity": "develop",
-    "shebangs": []
+    "reverse_exts": [".vue"],
+    "maturity": "develop"
   },
   {
     "id": "yaml",
     "name": "YAML",
     "keys": ["yaml"],
-    "exts": [".yml", ".yaml"],
+    "reverse_exts": [".yml", ".yaml"],
     "example_ext": ".yaml",
-    "maturity": "alpha",
-    "shebangs": []
+    "maturity": "alpha"
   }
 ]


### PR DESCRIPTION
I changed some assumptions about the `exts` and `reverse_exts`. It's nothing huge, but I'll have to review the code that uses it.

This is work in progress. I'll get back to it another day.