### PR TITLE
HCL: add .hcl extension

### DIFF
--- a/lang.json
+++ b/lang.json
@@ -238,7 +238,7 @@
     "id": "hcl",
     "name": "Terraform",
     "keys": ["tf", "hcl", "terraform"],
-    "exts": [".tf"],
+    "exts": [".tf", ".hcl"],
     "maturity": "beta",
     "shebangs": []
   },


### PR DESCRIPTION
Add the `.hcl` extension to the HCL language. Other tools than Terraform uses HCL and often use the `.hcl` extension. For example: [Terragrunt](https://terragrunt.gruntwork.io/)