### PR TITLE
Add Apex to the list of languages

### DIFF
--- a/lang.json
+++ b/lang.json
@@ -1,5 +1,13 @@
 [
   {
+    "id": "apex",
+    "name": "Apex",
+    "keys": ["apex"],
+    "exts": [".cls"],
+    "maturity": "develop",
+    "shebangs": []
+  },
+  {
     "id": "bash",
     "name": "Bash",
     "keys": ["bash", "sh"],


### PR DESCRIPTION
Apex support will be proprietary. At some point, we'll have to figure out if we need to add this info to `lang.json`.