### PR TITLE
chore: proprietary flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,7 @@ language; should be non-empty.
   in documentation; "develop" is not displayed in documentation.
 * **shebangs**: Programs that execute scripts written in this language. May be empty.
 * **tags**: An arbitrary list of string tags; useful to replace
-  a hard-coded switch on languages in a program.
+  a hard-coded switch on languages in a program. Current tags include:
+  -  `is_proprietary` - for proprietary languages like Apex
+  - `is_js` - for Javascript and Typescript
+  - `is_python` - for Python, Python2, Python3

--- a/lang.json
+++ b/lang.json
@@ -5,7 +5,8 @@
     "keys": ["apex"],
     "exts": [".cls"],
     "maturity": "develop",
-    "shebangs": []
+    "shebangs": [],
+    "tags": ["is_proprietary"]
   },
   {
     "id": "bash",


### PR DESCRIPTION
added a tag to the Apex language which signals it as proprietary.

This lets me write an `is_proprietary` function for `Lang` in https://github.com/returntocorp/semgrep/pull/7096