### PR TITLE
Add 'dockerfile' as a Dockerfile file name

### DIFF
--- a/lang.json
+++ b/lang.json
@@ -70,7 +70,7 @@
     "id": "dockerfile",
     "name": "Dockerfile",
     "keys": ["dockerfile", "docker"],
-    "exts": [".dockerfile", ".Dockerfile", "Dockerfile"],
+    "exts": [".dockerfile", ".Dockerfile", "Dockerfile", "dockerfile"],
     "example_ext": ".dockerfile",
     "maturity": "alpha",
     "shebangs": []


### PR DESCRIPTION
Dockerfiles can be called `dockerfile` as well as `Dockerfile`. Support both.